### PR TITLE
F1 browser help fix to compile on Mac

### DIFF
--- a/AGK/AGK.txt
+++ b/AGK/AGK.txt
@@ -11,6 +11,7 @@ Build Studio 2024.05.08
 - Add link to AppGAmeKit Documentation in the Help Menu
 - Fix missing AGK icon on title bar
 - Fix keyboard shortcut Duplicate Lines
+- Add change log to help menu
 
 Build Studio 2024.02.17
 -----------------------

--- a/AGK/AgkIde/Gui.cpp
+++ b/AGK/AgkIde/Gui.cpp
@@ -350,13 +350,15 @@ void ProcessPreferences(void) {
 			pref.iRememberTabOrder = bTmp;
 			if (ImGui::IsItemHovered()) ImGui::SetTooltip("Will remember the order of Visible tabs.\nNon-visible tabs will be in a-z order.");
 
+#ifdef AGK_WINDOWS //windows only, other platforms to be added later
+
 			bTmp = pref.bBrowserHelp;
 			ImGui::Checkbox("Enable F1 Browser Help", &bTmp);
 			pref.bBrowserHelp = bTmp;
 			if (ImGui::IsItemHovered()) ImGui::SetTooltip("Use browser help instead of the built in help");
 
+#endif
 			ImGui::Separator();
-
 
 			ImGui::SliderInt("Scene: Float Decimal Precision", &pref.iSceneLowFloatPrecision, 0, 8);
 			//ImGui::Checkbox("Scene Editor: Use 2 Decimal Precision For Float", &pref.bSceneLowFloatPrecision);

--- a/AGK/AgkIde/Ide.cpp
+++ b/AGK/AgkIde/Ide.cpp
@@ -3878,7 +3878,17 @@ int app::Loop (void)
 				if (ImGui::MenuItem("AppGameKit Player for IOS")) {
 					agk::OpenBrowser("https://itunes.apple.com/us/app/appgamekit-player/id1071731293?mt=8");
 				}
+				
+#ifdef AGK_WINDOWS //windows only, other platforms to be added later
+				ImGui::Separator();
 
+				if (ImGui::MenuItem("Change Log")) {
+					uString usDoc = startupFolder;
+					usDoc.Append("/media/Help/whats_new.html");
+					usDoc.ReplaceStr("\\", "/");
+					agk::OpenBrowser(usDoc.GetStr());
+				}							
+#endif				
 
 #ifdef TRIALVERSIONEXPIRES
 				ImGui::Separator();

--- a/AGK/AgkIde/Ide.h
+++ b/AGK/AgkIde/Ide.h
@@ -17,7 +17,7 @@
 #define DEVICE_HEIGHT 1024
 
 #define TRIALVERSION 4 //New trial version gives another 14 days trial to current trial users.
-#define VERSION "v2024.05.03"
+#define VERSION "v2024.05.08"
 #define INTVERSION 114 //Used to trigger auto update "additional files" and update Android export files
 
 #define WINDOW_TITLE "AppGameKit Studio " VERSION

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -940,10 +940,9 @@ void TextEditor::Help( void )
 	if (strlen(cHelp) < 2)
 		return;
 
-    /* NOTE: Lee did this to get XCODE 15.2 to play nicely
 	//Try to find help.
-	char currDir[1024];
-	GetCurrentDirectoryA(1024, currDir);
+	char buffer[1024];
+	char* currDir = getcwd(buffer, sizeof(buffer));
 
 	int index = tolower( char(cHelp[0]) );
 	uString usHelp = cHelp;
@@ -964,10 +963,14 @@ void TextEditor::Help( void )
 					}
 					//browser help
 					else {
-						strcat(currDir, "\\");
-						strcat(currDir, (char*)sKeyNext->m_cCommandPath.GetStr());
-						
-						agk::OpenBrowser(currDir);
+
+						if (currDir)
+						{
+							strcat(currDir, "\\");
+							strcat(currDir, (char*)sKeyNext->m_cCommandPath.GetStr());
+
+							agk::OpenBrowser(currDir);
+						}	
 
 					}
 					break;
@@ -977,7 +980,6 @@ void TextEditor::Help( void )
 		}
 
 	}
-    */
 
 	return;
 }

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -941,8 +941,13 @@ void TextEditor::Help( void )
 		return;
 
 	//Try to find help.
-	char buffer[1024];
-	char* currDir = getcwd(buffer, sizeof(buffer));
+	char curDir[MAX_PATH];
+
+#ifdef AGK_WINDOWS
+	_getcwd(&curDir[0], MAX_PATH);
+#else
+	getcwd(&curDir[0], MAX_PATH);
+#endif
 
 	int index = tolower( char(cHelp[0]) );
 	uString usHelp = cHelp;
@@ -964,13 +969,10 @@ void TextEditor::Help( void )
 					//browser help
 					else {
 
-						if (currDir)
-						{
-							strcat(currDir, "\\");
-							strcat(currDir, (char*)sKeyNext->m_cCommandPath.GetStr());
+						strcat(curDir, "\\");
+						strcat(curDir, (char*)sKeyNext->m_cCommandPath.GetStr());
 
-							agk::OpenBrowser(currDir);
-						}	
+						agk::OpenBrowser(curDir);
 
 					}
 					break;

--- a/AGK/apps/interpreter_android_amazon/AGKPlayer2/src/main/AndroidManifest.xml
+++ b/AGK/apps/interpreter_android_amazon/AGKPlayer2/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
       xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
       android:versionCode="109"
-      android:versionName="2024.04.22" package="com.thegamecreators.agk_player2" android:installLocation="auto">
+      android:versionName="2024.05.08" package="com.thegamecreators.agk_player2" android:installLocation="auto">
     <uses-feature android:glEsVersion="0x00020000"/>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/AGK/apps/interpreter_android_google/AGKPlayer2/src/main/AndroidManifest.xml
+++ b/AGK/apps/interpreter_android_google/AGKPlayer2/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="110"
-    android:versionName="2024.04.22"
+    android:versionName="2024.05.08"
     package="com.thegamecreators.agk_player2"
     android:installLocation="preferExternal">
 


### PR DESCRIPTION
Hi Lee, can you try this to see if it compiles on the Mac. I have used getcwd which is cross platform compatible.

If it compiles OK then to test start the IDE, open preferences, select Enable F1 Browser Help and then click on a AGK command in the editor, press F1 and the command info should be shown in the browser.