### PR TITLE
Fix for F1 and Index of commands

### DIFF
--- a/AGK/AgkIde/Ide.h
+++ b/AGK/AgkIde/Ide.h
@@ -17,7 +17,7 @@
 #define DEVICE_HEIGHT 1024
 
 #define TRIALVERSION 4 //New trial version gives another 14 days trial to current trial users.
-#define VERSION "v2024.05.03"
+#define VERSION "v2024.05.20"
 #define INTVERSION 114 //Used to trigger auto update "additional files" and update Android export files
 
 #define WINDOW_TITLE "AppGameKit Studio " VERSION

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -12,6 +12,10 @@
 #include "TextEditor.h"
 #include "AGKCommands.h"
 
+#ifdef AGK_WINDOWS
+#include <direct.h>
+#endif
+
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui/imgui.h" // for imGui::GetCurrentWindow()
 
@@ -941,12 +945,12 @@ void TextEditor::Help( void )
 		return;
 
 	//Try to find help.
-	char currDir[1024];
+	char curDir[MAX_PATH];
+
 #ifdef AGK_WINDOWS
-		//_getcwd(&curDir[0], MAX_PATH); needed <direct.h>
-		GetCurrentDirectoryA(1024, currDir);
+		_getcwd(&curDir[0], MAX_PATH); 
 #else
-		getcwd(&curDir[0], 1024);
+		getcwd(&curDir[0], MAX_PATH);
 #endif
 
 	int index = tolower( char(cHelp[0]) );
@@ -968,10 +972,10 @@ void TextEditor::Help( void )
 					}
 					//browser help
 					else {
-						strcat(currDir, "\\");
-						strcat(currDir, (char*)sKeyNext->m_cCommandPath.GetStr());
+						strcat(curDir, "\\");
+						strcat(curDir, (char*)sKeyNext->m_cCommandPath.GetStr());
 						
-						agk::OpenBrowser(currDir);
+						agk::OpenBrowser(curDir);
 
 					}
 					break;

--- a/AGK/AgkIde/files.cpp
+++ b/AGK/AgkIde/files.cpp
@@ -1638,7 +1638,7 @@ void renderTheText(uString renderText, bool entercodemode, bool bSeperator)
 	return;
 }
 
-#define MAXHELPFILESIZE 32768
+#define MAXHELPFILESIZE 141696 //orginal value 32768 (512 commands * 64, new value 141696 (2214 commands * 64)
 static char cHelpPagePath[MAX_PATH];
 static char cHelpFolder[MAX_PATH];
 static char cHelpPage[MAXHELPFILESIZE + 2];


### PR DESCRIPTION
Added #include direct.h to texteditor.cpp and changed code so that it is consistent with the IDE and GUI approach. Corrected misspelling of curDir. Tested on Windows OK

Changed files.cpp to display all of the 2214 commands in the help commands index instead of only 512 commands.