### PR TITLE
Update GUI.cpp billing to 6.0.1

### DIFF
--- a/AGK/AGK.txt
+++ b/AGK/AGK.txt
@@ -1,6 +1,11 @@
 AGK Change Log
 ==============
 
+Build Studio 2024.07.07
+-----------------------
+
+- Update billing to 6.0.1
+
 Build Studio 2024.06.09
 -----------------------
 

--- a/AGK/AgkIde/Gui.cpp
+++ b/AGK/AgkIde/Gui.cpp
@@ -7993,7 +7993,7 @@ void ProcessAndroidExport(void)
 						strcat(newcontents, "\n\
 						<meta-data\n\
 							android:name=\"com.google.android.play.billingclient.version\"\n\
-							android:value=\"5.2.1\" />\n\
+							android:value=\"6.0.1\" />\n\
 						<activity\n\
 							android:name=\"com.android.billingclient.api.ProxyBillingActivity\"\n\
 							android:configChanges=\"keyboard|keyboardHidden|screenLayout|screenSize|orientation\"\n\

--- a/AGK/AgkIde/Ide.h
+++ b/AGK/AgkIde/Ide.h
@@ -17,7 +17,7 @@
 #define DEVICE_HEIGHT 1024
 
 #define TRIALVERSION 4 //New trial version gives another 14 days trial to current trial users.
-#define VERSION "v2024.06.09"
+#define VERSION "v2024.07.07"
 #define INTVERSION 114 //Used to trigger auto update "additional files" and update Android export files
 
 #define WINDOW_TITLE "AppGameKit Studio " VERSION


### PR DESCRIPTION
Update GUI.cpp billing to 6.0.1 as the current Steam release is still targeting 5.2.1.

I have released a IDE.exe in my fork and Zappo has confirmed his apps are now targeting billing 6.0.1 and they have passed Google checks.