### PR TITLE
Studio IDE - f1 browser help fallback - home.html + enable f1 browser help pref for linux

### DIFF
--- a/AGK/AgkIde/Gui.cpp
+++ b/AGK/AgkIde/Gui.cpp
@@ -350,7 +350,7 @@ void ProcessPreferences(void) {
 			pref.iRememberTabOrder = bTmp;
 			if (ImGui::IsItemHovered()) ImGui::SetTooltip("Will remember the order of Visible tabs.\nNon-visible tabs will be in a-z order.");
 
-#ifdef AGK_WINDOWS
+#if defined(AGK_WINDOWS) || defined(AGK_LINUX)
 			bTmp = pref.bBrowserHelp;
 			ImGui::Checkbox("Enable F1 Browser Help", &bTmp);
 			pref.bBrowserHelp = bTmp;

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -934,7 +934,7 @@ void TextEditor::Help( void )
 	}
 
 	bool bNoCommandHelp = strlen(cHelp) < 2;
-	if (bNoCommandHelp && pref.bBrowserHelp == false)
+	if (bNoCommandHelp && !pref.bBrowserHelp)
 		return;
 
 	//Try to find help.
@@ -967,7 +967,7 @@ void TextEditor::Help( void )
 				if (sKeyNext->m_cCommandPath.GetLength() > 0 ) {
 					
 					//built in help
-					if (pref.bBrowserHelp == false) {
+					if (!pref.bBrowserHelp) {
 						processhelp((char*)sKeyNext->m_cCommandPath.GetStr(), true);
 						ImGui::SetWindowFocus(ICON_MD_HELP  " Help");
 					}
@@ -979,12 +979,18 @@ void TextEditor::Help( void )
 						agk::OpenBrowser(curDir);
 					}
 					
-					break;
+					return;
 				}
 			}
 			sKeyNext = sKeyNext->m_pNext;
 		}
 
+	}
+
+	if (pref.bBrowserHelp) //failed to find command; use home fallback for browser help
+	{
+		strcat(curDir, "/media/help/home.html");
+		agk::OpenBrowser(curDir);
 	}
 
 	return;

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -933,7 +933,8 @@ void TextEditor::Help( void )
 		}
 	}
 
-	if (strlen(cHelp) < 2)
+	bool bNoCommandHelp = strlen(cHelp) < 2;
+	if (bNoCommandHelp && pref.bBrowserHelp == false)
 		return;
 
 	//Try to find help.
@@ -944,6 +945,14 @@ void TextEditor::Help( void )
 #else
 	getcwd(&curDir[0], MAX_PATH);
 #endif
+
+	if (bNoCommandHelp)
+	{
+		strcat(curDir, "/media/help/home.html");
+
+		agk::OpenBrowser(curDir);
+		return;
+	}
 
 	int index = tolower( char(cHelp[0]) );
 	uString usHelp = cHelp;

--- a/AGK/AgkIde/TextEditor.cpp
+++ b/AGK/AgkIde/TextEditor.cpp
@@ -942,13 +942,16 @@ void TextEditor::Help( void )
 
 #ifdef AGK_WINDOWS
 	_getcwd(&curDir[0], MAX_PATH);
+#elif defined(AGK_LINUX)
+	strcpy(curDir, "file://");
+	getcwd(&curDir[7], MAX_PATH - 7);
 #else
 	getcwd(&curDir[0], MAX_PATH);
 #endif
 
 	if (bNoCommandHelp)
 	{
-		strcat(curDir, "/media/help/home.html");
+		strcat(curDir, "/media/Help/home.html");
 
 		agk::OpenBrowser(curDir);
 		return;
@@ -973,7 +976,7 @@ void TextEditor::Help( void )
 					}
 					//browser help
 					else {
-						strcat(curDir, "\\");
+						strcat(curDir, "/");
 						strcat(curDir, (char*)sKeyNext->m_cCommandPath.GetStr());
 
 						agk::OpenBrowser(curDir);
@@ -989,7 +992,7 @@ void TextEditor::Help( void )
 
 	if (pref.bBrowserHelp) //failed to find command; use home fallback for browser help
 	{
-		strcat(curDir, "/media/help/home.html");
+		strcat(curDir, "/media/Help/home.html");
 		agk::OpenBrowser(curDir);
 	}
 


### PR DESCRIPTION
Starting with Build Studio 2024.05.20 Zaxxan added the preference option to always use the browser for F1 help.
However, if there wasn't any valid command, there was no reaction at all.

This change will open the home.html if no command is found.
Furthermore it will enable the pref option for linux too (the linux related change was tested on ubuntu).